### PR TITLE
workaround: {.global.} pragma issue (--mm:orc, --mm:arc, nim-2.00 or later)

### DIFF
--- a/examples/LinePlots.nim
+++ b/examples/LinePlots.nim
@@ -1,0 +1,4 @@
+This file has been moved to
+
+https://github.com/dinau/nim_implot/blob/main/examples/demo/plots/LinePlots.nim
+

--- a/examples/LogScale.nim
+++ b/examples/LogScale.nim
@@ -1,0 +1,3 @@
+This file has been moved to
+
+https://github.com/dinau/nim_implot/blob/main/examples/demo/axes/LogScale.nim

--- a/examples/demo/axes/TimeScale.nim
+++ b/examples/demo/axes/TimeScale.nim
@@ -53,11 +53,13 @@ proc demo_Axes_TimeScale*() =
   igSameLine()
   igCheckbox("24 Hour Clock",ipGetStyle().use24HourClock.addr)
 
-  var  data{.global.}:HugeTimeData = nullptr
+  var  data{.global.}: HugeTimeData = nullptr
+  var sdata{.global.}: HugeTimeData
   if data == nullptr:
     igSameLine()
     if igButton("Generate Huge Data (~500MB!)"):
-      var sdata{.global.} = newHugeTimeData(t_min)
+      once:
+        sdata = newHugeTimeData(t_min) # TODO: Use --mm:refc
       data = sdata
 
   if ipBeginPlot("##Time", ImVec2(x: -1,y: 0)):

--- a/examples/demo/config.nims
+++ b/examples/demo/config.nims
@@ -1,5 +1,8 @@
-#switch "path","../../src"
+# for development local path
+switch "path","../../../nimgl-imgui/src" # for imgui
+switch "path","../../src" # for implot
 
+#
 switch "path","."
 switch "path","plots"
 switch "path","axes"
@@ -9,7 +12,6 @@ switch "path","custom"
 switch "path","config"
 switch "path","help"
 
-#switch "path","../../nimgl-imgui/src"
 switch "warning","HoleEnumConv:off"
 
 # Compilation options
@@ -17,7 +19,7 @@ switch "define","release"
 switch "nimcache",".nimcache"
 
 # Notice: Very important option at this time for Nim-2.0.0. TODO
-# Effects DigitalPlots.nim
+# Effects axes/TimeScale.nim
 switch "mm","refc"
 #when (NimMajor, NimMinor, NimPatch) >= (2, 0, 0):
 #  switch "mm","refc"

--- a/examples/demo/config/Config.nim
+++ b/examples/demo/config/Config.nim
@@ -18,7 +18,9 @@ proc demo_Config_Config*() =
   igSeparator()
   if ipBeginPlot("Preview"):
     defer: ipEndPlot()
-    var nowd {.global.} = epochTime().cdouble
+    var nowd {.global.}:cdouble
+    once:
+      nowd = epochTime().cdouble
     ipSetupAxisScale(ImAxis.X1, ImPlotScale.Time)
     ipSetupAxisLimits(ImAxis.X1, nowd, nowd + 24 * 3600)
     for i in 0..<10:


### PR DESCRIPTION
workaround: {.global.} pragma issue (--mm:orc, --mm:arc, nim-2.00 or later)
